### PR TITLE
Word salad

### DIFF
--- a/pep-513.rst
+++ b/pep-513.rst
@@ -34,7 +34,7 @@ as ``pip``.
 
 For Linux, the situation is much more delicate. In general, compiled Python
 extension modules built on one Linux distribution will not work on other Linux
-distributions, or even on the different machines running the same Linux
+distributions, or even on different machines running the same Linux
 distribution with different system libraries installed.
 
 Build tools using PEP 425 platform tags [1]_ do not track information about the

--- a/pep-513.rst
+++ b/pep-513.rst
@@ -17,9 +17,9 @@ Abstract
 
 This PEP proposes the creation of a new platform tag for Python package built
 distributions, such as wheels, called ``manylinux1_{x86_64,i386}`` with
-external dependencies limited restricted to a standardized subset of
+external dependencies limited to a standardized, restricted subset of
 the Linux kernel and core userspace ABI. It proposes that PyPI support
-uploading and distributing Wheels with this platform tag, and that ``pip``
+uploading and distributing wheels with this platform tag, and that ``pip``
 support downloading and installing these packages on compatible platforms.
 
 
@@ -34,8 +34,8 @@ as ``pip``.
 
 For Linux, the situation is much more delicate. In general, compiled Python
 extension modules built on one Linux distribution will not work on other Linux
-distributions, or even on the same Linux distribution with different system
-libraries installed.
+distributions, or even on the different machines running the same Linux
+distribution with different system libraries installed.
 
 Build tools using PEP 425 platform tags [1]_ do not track information about the
 particular Linux distribution or installed system libraries, and instead assign
@@ -93,7 +93,7 @@ libraries.
 Versioning of Core Shared Libraries
 -----------------------------------
 
-Even if the authors or maintainers of a Python extension module wish to use no
+Even if the developers a Python extension module wish to use no
 external shared libraries, the modules will generally have a dynamic runtime
 dependency on the GNU C library, ``glibc``. While it is possible, statically
 linking ``glibc`` is usually a bad idea because of bloat, and because certain
@@ -108,8 +108,8 @@ opposite is generally not true -- binaries compiled on newer Linux
 distributions tend to rely upon versioned functions in glibc that are not
 available on older systems.
 
-This generally prevents built distributions compiled on the latest Linux
-distributions from being portable.
+This generally prevents wheels compiled on the latest Linux distributions
+from being portable.
 
 
 The ``manylinux1`` policy
@@ -122,9 +122,9 @@ For these reasons, to achieve broad portability, Python wheels
  * should depend only on ``old`` symbol versions in those external shared
    libraries.
 
-The ``manylinux1`` policy thus encompasses a standard for what the
-permitted external shared libraries a wheel may depend on, and the maximum
-depended-upon symbol versions therein.
+The ``manylinux1`` policy thus encompasses a standard for what external shared
+libraries a wheel may depend on, and the maximum depended-upon symbol versions
+therein.
 
 The permitted external shared libraries are: ::
 
@@ -161,7 +161,7 @@ On RPM-based systems, these libraries are provided by the packages ::
     libICE libSM mesa-libGL glib2
 
 This list was compiled by checking the external shared library dependencies of
-the Canopy [1]_ and Anaconda [2]_ distributions, which both include a wide array
+the Canopy [2]_ and Anaconda [3]_ distributions, which both include a wide array
 of the most popular Python modules and have been confirmed in practice to work
 across a wide swath of Linux systems in the wild.
 
@@ -176,7 +176,7 @@ libraries, the following symbol versions are permitted: ::
 These symbol versions were determined by inspecting the latest symbol version
 provided in the libraries distributed with CentOS 5, a Linux distribution
 released in April 2007. In practice, this means that Python wheels which conform
-to this policy should function on almost any linux distribution released after
+to this policy should function on almost any Linux distribution released after
 this date.
 
 
@@ -191,7 +191,7 @@ easy to use self-contained build box for compiling ``manylinux1`` wheels [4]_.
 Compiling on a more recently-released linux distribution will generally
 introduce dependencies on too-new versioned symbols. The image comes with a
 full compiler suite installed (``gcc``, ``g++``, and ``gfortran`` 4.8.2) as
-well as the latest releases of Python and pip.
+well as the latest releases of Python and ``pip``.
 
 The second tool is a command line executable called ``auditwheel`` [5]_. First,
 it inspects all of the ELF files inside a wheel to check for dependencies on
@@ -226,7 +226,7 @@ arise in practice:
 
 * A linux distribution that is too old (e.g. RHEL 4)
 * A linux distribution that does not use glibc (e.g. Alpine Linux, which is
-  based on musl libc, or Android)
+  based on musl ``libc``, or Android)
 * Eventually, in the future, there may exist distributions that break
   compatibility with this profile
 
@@ -288,17 +288,17 @@ Security Implications
 
 One of the advantages of dependencies on centralized libraries in Linux is
 that bugfixes and security updates can be deployed system-wide, and
-applications which depend on on these libraries will automatically feel the
+applications which depend on these libraries will automatically feel the
 effects of these patches when the underlying libraries are updated. This can
-be particularly important for security updates in packages communication
-across the network or cryptography.
+be particularly important for security updates in packages engaged in
+communication across the network or cryptography.
 
 ``manylinux1`` wheels distributed through PyPI that bundle security-critical
 libraries like OpenSSL will thus assume responsibility for prompt updates in
 response disclosed vulnerabilities and patches. This closely parallels the
 security implications of the distribution of binary wheels on Windows that,
 because the platform lacks a system package manager, generally bundle their
-dependencies. In particular, because its lacks a stable ABI, OpenSSL cannot be
+dependencies. In particular, because it lacks a stable ABI, OpenSSL cannot be
 included in the ``manylinux1`` profile.
 
 

--- a/pep-513.rst
+++ b/pep-513.rst
@@ -93,7 +93,7 @@ libraries.
 Versioning of Core Shared Libraries
 -----------------------------------
 
-Even if author or maintainers of a Python extension module with to use no
+Even if the authors or maintainers of a Python extension module wish to use no
 external shared libraries, the modules will generally have a dynamic runtime
 dependency on the GNU C library, ``glibc``. While it is possible, statically
 linking ``glibc`` is usually a bad idea because of bloat, and because certain


### PR DESCRIPTION
Fixes some grammatical errors and typos, particularly the egregious "Even if author or maintainers of a Python extension module with to use no external shared libraries"