### PR TITLE
Fix two substantive bugs in the PEP text

### DIFF
--- a/pep-513.rst
+++ b/pep-513.rst
@@ -17,7 +17,7 @@ Abstract
 ========
 
 This PEP proposes the creation of a new platform tag for Python package built
-distributions, such as wheels, called ``manylinux1_{x86_64,i386}`` with
+distributions, such as wheels, called ``manylinux1_{x86_64,i686}`` with
 external dependencies limited to a standardized, restricted subset of
 the Linux kernel and core userspace ABI. It proposes that PyPI support
 uploading and distributing wheels with this platform tag, and that ``pip``
@@ -40,7 +40,7 @@ distribution with different system libraries installed.
 
 Build tools using PEP 425 platform tags [3]_ do not track information about the
 particular Linux distribution or installed system libraries, and instead assign
-all wheels the too-vague ``linux_i386`` or ``linux_x86_64`` tags. Because of
+all wheels the too-vague ``linux_i686`` or ``linux_x86_64`` tags. Because of
 this ambiguity, there is no expectation that ``linux``-tagged built
 distributions compiled on one machine will work properly on another, and for
 this reason, PyPI has not permitted the uploading of wheels for Linux.
@@ -159,7 +159,7 @@ versions), there is an extra requirement that (c) the wheel be
 built against a version of CPython compiled with 4-byte unicode
 support (i.e. one where ``sys.maxunicode > 0xFFFF``).
 
-Because CentOS 5 is only available for x86_64 and i386 architectures,
+Because CentOS 5 is only available for x86_64 and i686 architectures,
 these are the only architectures currently supported by the ``manylinux1``
 policy.
 
@@ -384,9 +384,9 @@ for the overall age of the distribution).
 Specifically, the algorithm we propose is::
 
     def is_manylinux1_compatible():
-        # Only Linux, and only x86-64 / i386
+        # Only Linux, and only x86-64 / i686
         from distutils.util import get_platform
-        if get_platform() not in ["linux_x86_64", "linux_i386"]:
+        if get_platform() not in ["linux-x86_64", "linux-i686"]:
             return False
 
         # "wide" Unicode mode is mandatory (always true on CPython 3.3+)
@@ -437,7 +437,7 @@ file, e.g. ``/etc/python/compatibility.cfg``. The problem with this is
 that a single filesystem might contain many different interpreter
 environments, each with their own ABI profile -- the ``manylinux1``
 compatibility of a system-installed x86_64 CPython might not tell us
-much about the ``manylinux1`` compatibility of a user-installed i386
+much about the ``manylinux1`` compatibility of a user-installed i686
 PyPy. Locating this configuration information within the Python
 environment itself ensures that it remains attached to the correct
 binary, and dramatically simplifies lookup code.


### PR DESCRIPTION
- All modern 32-bit linux uses linux_i686 for its tag, not
  linux_i386. My fault for trusting PEP 425. Confirmed by spinning up a
  real CentOS 5 VM in VirtualBox.
- distutils.util.get_platform() uses hyphens; they get normalized to
  underscore later. Fix the is_manylinux1_compatible() code to match.